### PR TITLE
HotFix: delete space floors

### DIFF
--- a/mod_celadon/mod_celadon.dme
+++ b/mod_celadon/mod_celadon.dme
@@ -1,0 +1,1 @@
+#include "turfs/_turf.dme"

--- a/mod_celadon/turfs/_turf.dme
+++ b/mod_celadon/turfs/_turf.dme
@@ -1,0 +1,1 @@
+#include "code/turf.dm"

--- a/mod_celadon/turfs/code/turf.dm
+++ b/mod_celadon/turfs/code/turf.dm
@@ -1,0 +1,44 @@
+/turf/open/floor/ms13/concrete/industrial/alt
+	icon_state = "concrete_industrial_alt"
+
+/turf/open/floor/ms13/concrete/industrial/split
+	icon_state = "concrete_industrial_split"
+    
+/turf/open/floor/ms13/concrete/industrial/walkway/end
+	icon_state = "concrete_walkway_end"
+
+/turf/open/floor/ms13/metal/warning
+	icon_state = "steel_warning"
+
+/turf/open/floor/ms13/metal/stayclear
+	icon_state = "steel_stayclear"
+
+/turf/open/floor/ms13/metal/border
+	icon_state = "steel_industrial_b"
+
+/turf/open/floor/ms13/metal/border/corner
+	icon_state = "steel_industrial_b_corner"
+
+/turf/open/floor/ms13/metal/border/sides
+	icon_state = "steel_industrial_b_sides"
+
+/turf/open/floor/ms13/metal/border/end
+	icon_state = "steel_industrial_b_end"
+
+/turf/open/floor/ms13/tile/brown/big
+	icon_state = "brown_big"
+	has_alternate_states = FALSE
+
+/turf/open/floor/ms13/tile/blue
+	icon_state = "blue"
+
+/turf/open/floor/ms13/tile/blue/long
+	icon_state = "blue_long"
+	alternate_states = 6
+
+/turf/open/floor/ms13/tile/large/cream
+	icon_state = "cream_large"
+	has_alternate_states = FALSE
+
+/turf/open/floor/ms13/metal/grate/alt
+	icon_state = "steel_grate_alt"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4795,3 +4795,6 @@
 #include "mojave\turfs\wall.dm"
 #include "mojave\turfs\window.dm"
 // END_INCLUDE
+
+// Celadon-ADD - Внедрение модульности
+#include "mod_celadon\mod_celadon.dme"


### PR DESCRIPTION
По причине того, что были вырезаны различные турфы - появились дырявые карты. 
Возвращаем удалённые турфы, чтобы убрать пустые зоны с космосом в игре.